### PR TITLE
feature: new preferences; fix: update lastDirectory on spawn from shell

### DIFF
--- a/HeroesONE_R_GUI/App.config
+++ b/HeroesONE_R_GUI/App.config
@@ -1,6 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="HeroesONE_R_GUI.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+
+    <userSettings>
+        <HeroesONE_R_GUI.Properties.Settings>
+            <setting name="HideWarnings" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="OpenAtCurrentFile" serializeAs="String">
+                <value>True</value>
+            </setting>
+        </HeroesONE_R_GUI.Properties.Settings>
+    </userSettings>
 </configuration>

--- a/HeroesONE_R_GUI/MainWindow.Designer.cs
+++ b/HeroesONE_R_GUI/MainWindow.Designer.cs
@@ -72,6 +72,8 @@ namespace HeroesONE_R_GUI
             this.compressionSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.enableAdaptiveCompressionLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.manuallySetCompressionLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.hideWarningsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.filePickerStartsAtOpenedFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.box_MenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.changeRWVersionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.extractToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -378,14 +380,14 @@ namespace HeroesONE_R_GUI
             // newToolStripMenuItem
             // 
             this.newToolStripMenuItem.Name = "newToolStripMenuItem";
-            this.newToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.newToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
             this.newToolStripMenuItem.Text = "New (Ctrl+N)";
             this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
             // 
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
             this.openToolStripMenuItem.Text = "Open (Ctrl+O)";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
@@ -394,21 +396,21 @@ namespace HeroesONE_R_GUI
             this.saveToolStripMenuItem.Checked = true;
             this.saveToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
             this.saveToolStripMenuItem.Text = "Save (Heroes)";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // saveShadow050ToolStripMenuItem
             // 
             this.saveShadow050ToolStripMenuItem.Name = "saveShadow050ToolStripMenuItem";
-            this.saveShadow050ToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.saveShadow050ToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
             this.saveShadow050ToolStripMenuItem.Text = "Save (Shadow 0.50)";
             this.saveShadow050ToolStripMenuItem.Click += new System.EventHandler(this.saveShadow050ToolStripMenuItem_Click);
             // 
             // saveShadow060ToolStripMenuItem
             // 
             this.saveShadow060ToolStripMenuItem.Name = "saveShadow060ToolStripMenuItem";
-            this.saveShadow060ToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.saveShadow060ToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
             this.saveShadow060ToolStripMenuItem.Text = "Save (Shadow 0.60)";
             this.saveShadow060ToolStripMenuItem.Click += new System.EventHandler(this.saveShadow060ToolStripMenuItem_Click);
             // 
@@ -433,7 +435,9 @@ namespace HeroesONE_R_GUI
             this.categoryBar_OptionsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.setArchiveRWVersionToolStripMenuItem,
             this.setAllFileRWVersionToolStripMenuItem,
-            this.compressionSettingsToolStripMenuItem});
+            this.compressionSettingsToolStripMenuItem,
+            this.hideWarningsToolStripMenuItem,
+            this.filePickerStartsAtOpenedFileToolStripMenuItem});
             this.categoryBar_OptionsMenuItem.ForeColor = System.Drawing.Color.Silver;
             this.categoryBar_OptionsMenuItem.Name = "categoryBar_OptionsMenuItem";
             this.categoryBar_OptionsMenuItem.Size = new System.Drawing.Size(61, 20);
@@ -442,14 +446,14 @@ namespace HeroesONE_R_GUI
             // setArchiveRWVersionToolStripMenuItem
             // 
             this.setArchiveRWVersionToolStripMenuItem.Name = "setArchiveRWVersionToolStripMenuItem";
-            this.setArchiveRWVersionToolStripMenuItem.Size = new System.Drawing.Size(195, 22);
+            this.setArchiveRWVersionToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
             this.setArchiveRWVersionToolStripMenuItem.Text = "Set Archive RW Version";
             this.setArchiveRWVersionToolStripMenuItem.Click += new System.EventHandler(this.setArchiveRWVersionToolStripMenuItem_Click);
             // 
             // setAllFileRWVersionToolStripMenuItem
             // 
             this.setAllFileRWVersionToolStripMenuItem.Name = "setAllFileRWVersionToolStripMenuItem";
-            this.setAllFileRWVersionToolStripMenuItem.Size = new System.Drawing.Size(195, 22);
+            this.setAllFileRWVersionToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
             this.setAllFileRWVersionToolStripMenuItem.Text = "Set All File RW Version";
             this.setAllFileRWVersionToolStripMenuItem.Click += new System.EventHandler(this.setAllFileRWVersionToolStripMenuItem_Click);
             // 
@@ -459,7 +463,7 @@ namespace HeroesONE_R_GUI
             this.enableAdaptiveCompressionLevelToolStripMenuItem,
             this.manuallySetCompressionLevelToolStripMenuItem});
             this.compressionSettingsToolStripMenuItem.Name = "compressionSettingsToolStripMenuItem";
-            this.compressionSettingsToolStripMenuItem.Size = new System.Drawing.Size(195, 22);
+            this.compressionSettingsToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
             this.compressionSettingsToolStripMenuItem.Text = "Compression Settings";
             // 
             // enableAdaptiveCompressionLevelToolStripMenuItem
@@ -478,6 +482,22 @@ namespace HeroesONE_R_GUI
             this.manuallySetCompressionLevelToolStripMenuItem.Size = new System.Drawing.Size(262, 22);
             this.manuallySetCompressionLevelToolStripMenuItem.Text = "Manually Set Compression Level";
             this.manuallySetCompressionLevelToolStripMenuItem.Click += new System.EventHandler(this.manuallySetCompressionLevelToolStripMenuItem_Click);
+            // 
+            // hideWarningsToolStripMenuItem
+            // 
+            this.hideWarningsToolStripMenuItem.CheckOnClick = true;
+            this.hideWarningsToolStripMenuItem.Name = "hideWarningsToolStripMenuItem";
+            this.hideWarningsToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
+            this.hideWarningsToolStripMenuItem.Text = "Hide Warnings";
+            this.hideWarningsToolStripMenuItem.Click += new System.EventHandler(this.hideWarningsToolStripMenuItem_Click);
+            // 
+            // filePickerStartsAtOpenedFileToolStripMenuItem
+            // 
+            this.filePickerStartsAtOpenedFileToolStripMenuItem.CheckOnClick = true;
+            this.filePickerStartsAtOpenedFileToolStripMenuItem.Name = "filePickerStartsAtOpenedFileToolStripMenuItem";
+            this.filePickerStartsAtOpenedFileToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
+            this.filePickerStartsAtOpenedFileToolStripMenuItem.Text = "File Picker Starts At Opened File";
+            this.filePickerStartsAtOpenedFileToolStripMenuItem.Click += new System.EventHandler(this.filePickerStartsAtOpenedFileToolStripMenuItem_Click);
             // 
             // box_MenuStrip
             // 
@@ -551,6 +571,7 @@ namespace HeroesONE_R_GUI
             this.MainMenuStrip = this.categoryBar_MenuStrip;
             this.Name = "MainWindow";
             this.Text = "Form1";
+            this.Load += new System.EventHandler(this.MainWindow_Load);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MainWindow_KeyDown);
             ((System.ComponentModel.ISupportInitialize)(this.box_FileList)).EndInit();
             this.titleBar_Panel.ResumeLayout(false);
@@ -601,6 +622,8 @@ namespace HeroesONE_R_GUI
         private System.Windows.Forms.ToolStripMenuItem saveShadow050ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveShadow060ToolStripMenuItem;
         private ToolStripMenuItem categoryBar_ExtractAll;
+        private ToolStripMenuItem hideWarningsToolStripMenuItem;
+        private ToolStripMenuItem filePickerStartsAtOpenedFileToolStripMenuItem;
     }
 }
 

--- a/HeroesONE_R_GUI/Program.cs
+++ b/HeroesONE_R_GUI/Program.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -20,10 +21,29 @@ namespace HeroesONE_R_GUI
             SetDefault();
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+            //Fix Reloaded Theme missing
+            string reloadedConfigPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) +
+                "\\Reloaded-Mod-Loader\\Reloaded-Config";
+            string asmPath = System.IO.Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + "\\theme";
+            if (!File.Exists(Path.Combine(reloadedConfigPath, "Config.json")))
+            {
+                Directory.CreateDirectory(reloadedConfigPath + "\\Themes\\!Reloaded\\Fonts");
+                Directory.CreateDirectory(reloadedConfigPath + "\\Themes\\!Reloaded\\Images");
+                File.Copy(asmPath + "\\Config.json", reloadedConfigPath + "\\Config.json");
+                File.Copy(asmPath + "\\Themes\\!Reloaded\\Config.json", reloadedConfigPath + "\\Themes\\!Reloaded\\Config.json");
+                File.Copy(asmPath + "\\Themes\\!Reloaded\\Theme.json", reloadedConfigPath + "\\Themes\\!Reloaded\\Theme.json");
+                File.Copy(asmPath + "\\Themes\\!Reloaded\\Fonts\\CategoryFont.ttf", reloadedConfigPath + "\\Themes\\!Reloaded\\Fonts\\CategoryFont.ttf");
+                File.Copy(asmPath + "\\Themes\\!Reloaded\\Fonts\\TextFont.ttf", reloadedConfigPath + "\\Themes\\!Reloaded\\Fonts\\TextFont.ttf");
+                File.Copy(asmPath + "\\Themes\\!Reloaded\\Fonts\\TitleFont.ttf", reloadedConfigPath + "\\Themes\\!Reloaded\\Fonts\\TitleFont.ttf");
+                foreach (var file in Directory.GetFiles(asmPath + "\\Themes\\!Reloaded\\Images"))
+                {
+                    File.Copy(file, reloadedConfigPath + "\\Themes\\!Reloaded\\Images\\" + Path.GetFileName(file));
+                }
+            }
+            //Until lib is updated
 
             if (args.Length > 0) { Application.Run(new MainWindow(args[0])); }
-            else { Application.Run(new MainWindow()); }
-            
+            else { Application.Run(new MainWindow()); }      
         }
 
         /// <summary>

--- a/HeroesONE_R_GUI/Properties/Settings.Designer.cs
+++ b/HeroesONE_R_GUI/Properties/Settings.Designer.cs
@@ -8,22 +8,42 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace HeroesONE_R_GUI.Properties
-{
-
-
+namespace HeroesONE_R_GUI.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HideWarnings {
+            get {
+                return ((bool)(this["HideWarnings"]));
+            }
+            set {
+                this["HideWarnings"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool OpenAtCurrentFile {
+            get {
+                return ((bool)(this["OpenAtCurrentFile"]));
+            }
+            set {
+                this["OpenAtCurrentFile"] = value;
             }
         }
     }

--- a/HeroesONE_R_GUI/Properties/Settings.settings
+++ b/HeroesONE_R_GUI/Properties/Settings.settings
@@ -1,7 +1,12 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="HeroesONE_R_GUI.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="HideWarnings" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="OpenAtCurrentFile" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>


### PR DESCRIPTION
### New Preferences (enable/disable in Options submenu):
- No Warnings [default: false]
-- hides the ShadowTheHedgehog filetype warning when opening an archive
- File Picker Starts At Opened File [default: true]
-- When executing open/save/replace/extract the location of the FileDialog will start at the same directory as the currently opened .one archive. Only the "open" operation will change the next open/save/replace/extract FileDialog's lastDirectory
-- When set to false all operations will change the next open/save/replace/extract lastDirectory

### Fix:
- Was not setting lastDirectory for files opened through shell
-- This also fixes the case where lastDirectory was invalid for QuickSave
- Hardcoded copy of default theme to reloaded roaming folder to suppress 'theme not found' message for users who do not have Reloaded-Mod-Loader installed ('theme' folder should be stuck into release archive)
