### PR TITLE
Drag & Drop Fixes & Add "Sort" feature for Shadow file order

### DIFF
--- a/HeroesONE_R_GUI/HeroesONE_R_GUI.csproj
+++ b/HeroesONE_R_GUI/HeroesONE_R_GUI.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>HeroesONE_R_GUI</RootNamespace>
     <AssemblyName>HeroesONE_R_GUI</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+	<LangVersion>latest</LangVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsWebBootstrapper>false</IsWebBootstrapper>
@@ -31,20 +32,23 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
+	<LangVersion>latest</LangVersion>
     <OutputPath>bin\build\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>default</LangVersion>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
+	<LangVersion>latest</LangVersion>
     <OutputPath>bin\build\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -59,7 +63,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>default</LangVersion>
+    <LangVersion>latest</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
@@ -70,6 +74,7 @@
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
+	<LangVersion>latest</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>

--- a/HeroesONE_R_GUI/MainWindow.Designer.cs
+++ b/HeroesONE_R_GUI/MainWindow.Designer.cs
@@ -67,6 +67,8 @@ namespace HeroesONE_R_GUI
             this.saveShadow060ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.categoryBar_ExtractAll = new System.Windows.Forms.ToolStripMenuItem();
             this.categoryBar_AddFiles = new System.Windows.Forms.ToolStripMenuItem();
+            this.categoryBar_Actions = new System.Windows.Forms.ToolStripMenuItem();
+            this.batchAction_replaceSelectedForManyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.categoryBar_OptionsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.setArchiveRWVersionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.setAllFileRWVersionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -82,8 +84,7 @@ namespace HeroesONE_R_GUI
             this.replaceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.deleteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.titleBar_StatusBar = new System.Windows.Forms.Panel();
-            this.categoryBar_BatchAction = new System.Windows.Forms.ToolStripMenuItem();
-            this.batchAction_replaceSelectedForManyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sortByExtensionsShadowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.box_FileList)).BeginInit();
             this.titleBar_Panel.SuspendLayout();
             this.categoryBar_MenuStrip.SuspendLayout();
@@ -364,7 +365,7 @@ namespace HeroesONE_R_GUI
             this.categoryBar_FileMenuItem,
             this.categoryBar_ExtractAll,
             this.categoryBar_AddFiles,
-            this.categoryBar_BatchAction,
+            this.categoryBar_Actions,
             this.categoryBar_OptionsMenuItem});
             this.categoryBar_MenuStrip.Location = new System.Drawing.Point(0, 42);
             this.categoryBar_MenuStrip.Name = "categoryBar_MenuStrip";
@@ -387,14 +388,14 @@ namespace HeroesONE_R_GUI
             // newToolStripMenuItem
             // 
             this.newToolStripMenuItem.Name = "newToolStripMenuItem";
-            this.newToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
+            this.newToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.newToolStripMenuItem.Text = "New (Ctrl+N)";
             this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
             // 
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.openToolStripMenuItem.Text = "Open (Ctrl+O)";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
@@ -403,21 +404,21 @@ namespace HeroesONE_R_GUI
             this.saveToolStripMenuItem.Checked = true;
             this.saveToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveToolStripMenuItem.Text = "Save (Heroes)";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // saveShadow050ToolStripMenuItem
             // 
             this.saveShadow050ToolStripMenuItem.Name = "saveShadow050ToolStripMenuItem";
-            this.saveShadow050ToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
+            this.saveShadow050ToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveShadow050ToolStripMenuItem.Text = "Save (Shadow 0.50)";
             this.saveShadow050ToolStripMenuItem.Click += new System.EventHandler(this.saveShadow050ToolStripMenuItem_Click);
             // 
             // saveShadow060ToolStripMenuItem
             // 
             this.saveShadow060ToolStripMenuItem.Name = "saveShadow060ToolStripMenuItem";
-            this.saveShadow060ToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
+            this.saveShadow060ToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveShadow060ToolStripMenuItem.Text = "Save (Shadow 0.60)";
             this.saveShadow060ToolStripMenuItem.Click += new System.EventHandler(this.saveShadow060ToolStripMenuItem_Click);
             // 
@@ -436,6 +437,23 @@ namespace HeroesONE_R_GUI
             this.categoryBar_AddFiles.Size = new System.Drawing.Size(67, 20);
             this.categoryBar_AddFiles.Text = "Add Files";
             this.categoryBar_AddFiles.Click += new System.EventHandler(this.categoryBar_AddFiles_Click);
+            // 
+            // categoryBar_Actions
+            // 
+            this.categoryBar_Actions.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.batchAction_replaceSelectedForManyToolStripMenuItem,
+            this.sortByExtensionsShadowToolStripMenuItem});
+            this.categoryBar_Actions.ForeColor = System.Drawing.Color.Silver;
+            this.categoryBar_Actions.Name = "categoryBar_Actions";
+            this.categoryBar_Actions.Size = new System.Drawing.Size(59, 20);
+            this.categoryBar_Actions.Text = "Actions";
+            // 
+            // batchAction_replaceSelectedForManyToolStripMenuItem
+            // 
+            this.batchAction_replaceSelectedForManyToolStripMenuItem.Name = "batchAction_replaceSelectedForManyToolStripMenuItem";
+            this.batchAction_replaceSelectedForManyToolStripMenuItem.Size = new System.Drawing.Size(223, 22);
+            this.batchAction_replaceSelectedForManyToolStripMenuItem.Text = "Replace Selected for many";
+            this.batchAction_replaceSelectedForManyToolStripMenuItem.Click += new System.EventHandler(this.replaceSelectToolStripMenuItem_Click);
             // 
             // categoryBar_OptionsMenuItem
             // 
@@ -563,21 +581,12 @@ namespace HeroesONE_R_GUI
             this.titleBar_StatusBar.Size = new System.Drawing.Size(362, 30);
             this.titleBar_StatusBar.TabIndex = 16;
             // 
-            // categoryBar_BatchAction
+            // sortByExtensionsShadowToolStripMenuItem
             // 
-            this.categoryBar_BatchAction.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.batchAction_replaceSelectedForManyToolStripMenuItem});
-            this.categoryBar_BatchAction.ForeColor = System.Drawing.Color.Silver;
-            this.categoryBar_BatchAction.Name = "categoryBar_BatchAction";
-            this.categoryBar_BatchAction.Size = new System.Drawing.Size(87, 20);
-            this.categoryBar_BatchAction.Text = "Batch Action";
-            // 
-            // batchAction_replaceSelectedForManyToolStripMenuItem
-            // 
-            this.batchAction_replaceSelectedForManyToolStripMenuItem.Name = "batchAction_replaceSelectedForManyToolStripMenuItem";
-            this.batchAction_replaceSelectedForManyToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
-            this.batchAction_replaceSelectedForManyToolStripMenuItem.Text = "Replace Selected for many";
-            this.batchAction_replaceSelectedForManyToolStripMenuItem.Click += new System.EventHandler(this.replaceSelectToolStripMenuItem_Click);
+            this.sortByExtensionsShadowToolStripMenuItem.Name = "sortByExtensionsShadowToolStripMenuItem";
+            this.sortByExtensionsShadowToolStripMenuItem.Size = new System.Drawing.Size(223, 22);
+            this.sortByExtensionsShadowToolStripMenuItem.Text = "Sort by extensions (EXPERIMENTAL)";
+            this.sortByExtensionsShadowToolStripMenuItem.Click += new System.EventHandler(this.SortByExtensionsShadowToolStripMenuItem_Click);
             // 
             // MainWindow
             // 
@@ -648,8 +657,9 @@ namespace HeroesONE_R_GUI
         private ToolStripMenuItem categoryBar_ExtractAll;
         private ToolStripMenuItem hideWarningsToolStripMenuItem;
         private ToolStripMenuItem filePickerStartsAtOpenedFileToolStripMenuItem;
-        private ToolStripMenuItem categoryBar_BatchAction;
+        private ToolStripMenuItem categoryBar_Actions;
         private ToolStripMenuItem batchAction_replaceSelectedForManyToolStripMenuItem;
+        private ToolStripMenuItem sortByExtensionsShadowToolStripMenuItem;
     }
 }
 

--- a/HeroesONE_R_GUI/MainWindow.cs
+++ b/HeroesONE_R_GUI/MainWindow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.SqlTypes;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -269,7 +270,15 @@ namespace HeroesONE_R_GUI
             // Get selected row if possible.
             int selectedRow = -1;
             if (box_FileList.SelectedCells.Count > 0)
-            { selectedRow = box_FileList.SelectedCells[0].RowIndex; }
+            {
+                selectedRow = box_FileList.SelectedCells[0].RowIndex;
+            }
+
+            int lastFirstDisplayedScrollingRowIndex = -1;
+            if (box_FileList.RowCount != 0)
+            {
+                lastFirstDisplayedScrollingRowIndex = box_FileList.FirstDisplayedScrollingRowIndex;
+            }
 
             // Update list
             box_FileList.Rows.Clear();
@@ -287,7 +296,13 @@ namespace HeroesONE_R_GUI
             try
             {
                 if (selectedRow != -1)
-                { box_FileList.Rows[selectedRow].Selected = true; }
+                { 
+                    box_FileList.Rows[selectedRow].Selected = true;
+                    if (lastFirstDisplayedScrollingRowIndex == -1)
+                        box_FileList.FirstDisplayedScrollingRowIndex = selectedRow;
+                    else
+                        box_FileList.FirstDisplayedScrollingRowIndex = lastFirstDisplayedScrollingRowIndex;
+                }
             }
             catch { }
         }
@@ -946,6 +961,48 @@ namespace HeroesONE_R_GUI
         {
             await Task.Delay(milliseconds);
             filePickerWasActive = false;
+        }
+
+        private string[] shadowOneExtensionOrder =
+        [
+            "SNB",
+            "EFD",
+            "DFF",
+            "TXD",
+            "UVA",
+            "BIN",
+            "CCL",
+            "BON",
+            "MTN",
+            "MTP",
+            "DMA",
+            "PTP",
+            "BDT",
+            "ADB",
+            "GNCP"
+        ];
+
+        private void SortByExtensionsShadowToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (Archive == null || Archive.Files.Count == 0)
+                return;
+            List<ArchiveFile> sortedData = [];
+            foreach (var extension in shadowOneExtensionOrder)
+            {
+                foreach (var file in Archive.Files)
+                {
+                    if (file.Name.EndsWith(extension))
+                    {
+                        sortedData.Add(file);
+                    }
+                }
+            }
+            if (Archive.Files.Count != sortedData.Count)
+            {
+                MessageBox.Show("Warning! Unsupported extensions were found in the file, and deleted after the sort operation.\nPlease report this to the developers!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            Archive.Files = sortedData;
+            UpdateGUI(ref Archive);
         }
     }
 }

--- a/HeroesONE_R_GUI/MainWindow.cs
+++ b/HeroesONE_R_GUI/MainWindow.cs
@@ -76,6 +76,7 @@ namespace HeroesONE_R_GUI
         private Rectangle dragBoxFromMouseDown;
         private int rowIndexFromMouseDown;
         private int rowIndexOfItemUnderMouseToDrop;
+        private bool filePickerWasActive = false;
 
         /// <summary>
         /// Sets up the current window and the Reloaded theme.
@@ -213,6 +214,7 @@ namespace HeroesONE_R_GUI
         /// <param name="e"></param>
         private void saveToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            filePickerWasActive = true;
             // Pick ONE file.
             CommonSaveFileDialog fileDialog = new CommonSaveFileDialog
             {
@@ -233,6 +235,7 @@ namespace HeroesONE_R_GUI
                     _lastOpenedDirectory = Path.GetDirectoryName(fileDialog.FileName);
                 _lastONEDirectory = Path.GetDirectoryName(fileDialog.FileName);
             }
+            ClearFilePickerWasActive();
         }
 
         /// <summary>
@@ -296,6 +299,8 @@ namespace HeroesONE_R_GUI
         /// <param name="e"></param>
         private void box_FileList_CellMouseClick(object sender, DataGridViewCellMouseEventArgs e)
         {
+            if (filePickerWasActive)
+                return;
             if (e.Button == MouseButtons.Right)
             {
                 // Gets our individual file to manipulate.
@@ -317,6 +322,7 @@ namespace HeroesONE_R_GUI
         /// <param name="e"></param>
         private void replaceToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            filePickerWasActive = true;
             // Pick file.
             CommonOpenFileDialog fileDialog = new CommonOpenFileDialog
             {
@@ -332,6 +338,7 @@ namespace HeroesONE_R_GUI
                 if (!Properties.Settings.Default.OpenAtCurrentFile)
                     _lastOpenedDirectory = Path.GetDirectoryName(fileDialog.FileName);
             }
+            ClearFilePickerWasActive();
         }
 
         /// <summary>
@@ -419,6 +426,7 @@ namespace HeroesONE_R_GUI
         /// <param name="e"></param>
         private void categoryBar_AddFiles_Click(object sender, EventArgs e)
         {
+            filePickerWasActive = true;
             // Pick file(s)
             CommonOpenFileDialog fileDialog = new CommonOpenFileDialog
             {
@@ -439,6 +447,7 @@ namespace HeroesONE_R_GUI
                     _lastOpenedDirectory = Path.GetDirectoryName(fileDialog.FileName);
                 UpdateGUI(ref Archive);
             }
+            ClearFilePickerWasActive();
         }
 
         /// <summary>
@@ -448,6 +457,7 @@ namespace HeroesONE_R_GUI
         /// <param name="e"></param>
         private void extractToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            filePickerWasActive = true;
             // Select path to extract to.
             CommonSaveFileDialog fileDialog = new CommonSaveFileDialog
             {
@@ -463,6 +473,7 @@ namespace HeroesONE_R_GUI
                 if (!Properties.Settings.Default.OpenAtCurrentFile)
                     _lastOpenedDirectory = Path.GetDirectoryName(fileDialog.FileName);
             }
+            ClearFilePickerWasActive();
         }
 
         /// <summary>
@@ -525,14 +536,17 @@ namespace HeroesONE_R_GUI
         /// <param name="e"></param>
         private void renameToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            filePickerWasActive = true;
             // Get file name.
             RenameDialog searchBufferDialog = new RenameDialog(ArchiveFile.Name);
             ArchiveFile.Name = searchBufferDialog.ShowDialog();
             UpdateGUI(ref Archive);
+            ClearFilePickerWasActive();
         }
 
         private void saveShadow050ToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            filePickerWasActive = true;
             // Pick ONE file.
             CommonSaveFileDialog fileDialog = new CommonSaveFileDialog
             {
@@ -553,10 +567,12 @@ namespace HeroesONE_R_GUI
                     _lastOpenedDirectory = Path.GetDirectoryName(fileDialog.FileName);
                 _lastONEDirectory = Path.GetDirectoryName(fileDialog.FileName);
             }
+            ClearFilePickerWasActive();
         }
 
         private void saveShadow060ToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            filePickerWasActive = true;
             // Pick ONE file.
             CommonSaveFileDialog fileDialog = new CommonSaveFileDialog
             {
@@ -577,6 +593,7 @@ namespace HeroesONE_R_GUI
                     _lastOpenedDirectory = Path.GetDirectoryName(fileDialog.FileName);
                 _lastONEDirectory = Path.GetDirectoryName(fileDialog.FileName);
             }
+            ClearFilePickerWasActive();
         }
 
         /// <summary>
@@ -584,6 +601,8 @@ namespace HeroesONE_R_GUI
         /// </summary>
         private void FileList_DragEnter(object sender, DragEventArgs e)
         {
+            if (filePickerWasActive)
+                return;
             // Contains the paths to the individual files.
             if (e.AllowedEffect == DragDropEffects.Move)
                 e.Effect = DragDropEffects.Move;
@@ -598,6 +617,8 @@ namespace HeroesONE_R_GUI
         /// </summary>
         private void FileList_DragDrop(object sender, DragEventArgs e)
         {
+            if (filePickerWasActive)
+                return;
             // The mouse locations are relative to the screen, so they must be 
             // converted to client coordinates.
             Point clientPoint = box_FileList.PointToClient(new Point(e.X, e.Y));
@@ -645,6 +666,7 @@ namespace HeroesONE_R_GUI
 
         private void categoryBar_ExtractAll_Click(object sender, EventArgs e)
         {
+            filePickerWasActive = true;
             // Select path to extract to.
             CommonOpenFileDialog fileDialog = new CommonOpenFileDialog
             {
@@ -665,6 +687,7 @@ namespace HeroesONE_R_GUI
                         _lastOpenedDirectory = Path.GetDirectoryName(fileDialog.FileName);
                 });
             }
+            ClearFilePickerWasActive();
         }
 
         // Other Keyboard shortcuts
@@ -804,6 +827,8 @@ namespace HeroesONE_R_GUI
 
         private void box_FileList_MouseDown(object sender, MouseEventArgs e)
         {
+            if (filePickerWasActive)
+                return;
             // Get the index of the item the mouse is below.
             rowIndexFromMouseDown = box_FileList.HitTest(e.X, e.Y).RowIndex;
             if (rowIndexFromMouseDown != -1) {
@@ -824,6 +849,8 @@ namespace HeroesONE_R_GUI
 
         private void box_FileList_MouseMove(object sender, MouseEventArgs e)
         {
+            if (filePickerWasActive)
+                return;
             if ((e.Button & MouseButtons.Left) == MouseButtons.Left)
             {
                 // If the mouse moves outside the rectangle, start the drag.
@@ -840,6 +867,8 @@ namespace HeroesONE_R_GUI
 
         private void box_FileList_DragOver(object sender, DragEventArgs e)
         {
+            if (filePickerWasActive)
+                return;
             if (e.AllowedEffect == DragDropEffects.Move)
                 e.Effect = DragDropEffects.Move;
             else if (e.Data.GetDataPresent(DataFormats.FileDrop))
@@ -850,6 +879,7 @@ namespace HeroesONE_R_GUI
 
         private void replaceSelectToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            filePickerWasActive = true;
             MessageBox.Show("This batch action will replace the selected file name in the current file across all .ones in the folder you pick (recursive).\n\n1. Choose the folder to modify .ones\n2. Choose the replacement file content");
             try
             {
@@ -909,6 +939,13 @@ namespace HeroesONE_R_GUI
                 File.WriteAllBytes(foundOnes[i], outputFile.ToArray());
             }
             MessageBox.Show("DONE");
+            ClearFilePickerWasActive();
+        }
+
+        private async Task ClearFilePickerWasActive(int milliseconds = 500)
+        {
+            await Task.Delay(milliseconds);
+            filePickerWasActive = false;
         }
     }
 }


### PR DESCRIPTION
Sort is not consistent in Shadow files, some are hardcoded. As such marked as experimental as such this is the format as I understand it. Again, some for example have SNB at bottom of files, so the user may need to drag & drop after. But it should still make importing other objects from other stages much easier with this change, as its compatible with .GDT files.
```
Shadow Parse Order
]
| - pairs like this are interchangable
]

SNB
EFD ]
DFF |
TXD | - interchangable
UVA ]
BIN
CCL
BON
MTN
MTP
DMA
PTP ]
BDT | - interchangable
ADB ]
GNCP
```

* Drag & Drop feature cleanup - previously had bad behavior where double clicking in file dialogs would leads to unintentional invoke of drag & drop over the selected index if it overlapped with the file dialog
* Drag & Drop auto scroll fixed for large files that have scrolling - no more awkward jumps when drag & dropping in this case.